### PR TITLE
change limit in obtener productos

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -64,9 +64,10 @@ def obtener_almacenes():
 
 # Esta función muestra los productos no vencidos en el almacén ID para el SKU indicado
 def obtener_productos_almacen(id_almacen, sku):
-    frase_a_hashear = 'GET{}{}'.format(id_almacen, sku)
+    limit = 200
+    frase_a_hashear = 'GET{}{}'.format(id_almacen, sku, limit)
     frase_hasheada = calcular_hash(frase_a_hashear)
-    url = url_base + '/stock?almacenId={}&sku={}'.format(id_almacen, sku)
+    url = url_base + '/stock?almacenId={}&sku={}&limit={}'.format(id_almacen, sku, limit)
     headers = {'Content-Type': 'application/json', 'Authorization': 'INTEGRACION grupo13:{}'.format(frase_hasheada)}
     result = requests.get(url, headers=headers)
     productos = json.loads(result.text)

--- a/app/services.py
+++ b/app/services.py
@@ -65,7 +65,7 @@ def obtener_almacenes():
 # Esta función muestra los productos no vencidos en el almacén ID para el SKU indicado
 def obtener_productos_almacen(id_almacen, sku):
     limit = 200
-    frase_a_hashear = 'GET{}{}'.format(id_almacen, sku, limit)
+    frase_a_hashear = 'GET{}{}'.format(id_almacen, sku)
     frase_hasheada = calcular_hash(frase_a_hashear)
     url = url_base + '/stock?almacenId={}&sku={}&limit={}'.format(id_almacen, sku, limit)
     headers = {'Content-Type': 'application/json', 'Authorization': 'INTEGRACION grupo13:{}'.format(frase_hasheada)}


### PR DESCRIPTION
- Revisé que el servicio siguiera funcionando (obtener productos almacen) y ahora efectivamente aumentó el máximo de elementos que retorna.

- El servicio además de usarse en empty_recepction y empty_pulmon se usa en move_product_destiny, que se utiliza en produce, que se usa en produce_order y best_attempt production. Como éstas dos son por lote, no debería haber problemas

- Además se usa en find and dispatch sushi (subtasks) tampoco hay problema en mi opinión